### PR TITLE
Compatibility with VTK >= 9.3.0

### DIFF
--- a/vtkThreshold/vtkThreshold.cxx
+++ b/vtkThreshold/vtkThreshold.cxx
@@ -44,13 +44,17 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mexErrMsgTxt("cellsOrPoints must be \"cells\" or \"points\".");
     
     double* thresholds = mxGetPr(prhs[3]);
-    if(!std::isfinite(thresholds[0]))
-        threshold->ThresholdByLower(thresholds[1]);
-    else if(!std::isfinite(thresholds[1]))
-        threshold->ThresholdByUpper(thresholds[0]);
-    else
-        threshold->ThresholdBetween(thresholds[0], thresholds[1]);
-        
+    if(!std::isfinite(thresholds[0])) {
+        threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_LOWER);
+        threshold->SetLowerThreshold(thresholds[1]);
+    } else if(!std::isfinite(thresholds[1])) {
+        threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
+        threshold->SetUpperThreshold(thresholds[0]);
+    } else {
+        threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_BETWEEN);
+        threshold->SetLowerThreshold(thresholds[0]);
+        threshold->SetUpperThreshold(thresholds[1]);
+    }
     threshold->Update();
     
     ///// Convert vtkPointSet into MATLAB struct /////

--- a/vtkThreshold/vtkThreshold.cxx
+++ b/vtkThreshold/vtkThreshold.cxx
@@ -44,17 +44,27 @@ void mexFunction(int nlhs, mxArray *plhs[], int nrhs, const mxArray *prhs[])
         mexErrMsgTxt("cellsOrPoints must be \"cells\" or \"points\".");
     
     double* thresholds = mxGetPr(prhs[3]);
-    if(!std::isfinite(thresholds[0])) {
-        threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_LOWER);
-        threshold->SetLowerThreshold(thresholds[1]);
-    } else if(!std::isfinite(thresholds[1])) {
-        threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
-        threshold->SetUpperThreshold(thresholds[0]);
-    } else {
-        threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_BETWEEN);
-        threshold->SetLowerThreshold(thresholds[0]);
-        threshold->SetUpperThreshold(thresholds[1]);
-    }
+    #if VTK_VERSION_NUMBER >= 901000000
+        if(!std::isfinite(thresholds[0])) {
+            threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_LOWER);
+            threshold->SetLowerThreshold(thresholds[1]);
+        } else if(!std::isfinite(thresholds[1])) {
+            threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_UPPER);
+            threshold->SetUpperThreshold(thresholds[0]);
+        } else {
+            threshold->SetThresholdFunction(vtkThreshold::THRESHOLD_BETWEEN);
+            threshold->SetLowerThreshold(thresholds[0]);
+            threshold->SetUpperThreshold(thresholds[1]);
+        }
+    #else
+        if(!std::isfinite(thresholds[0])) {
+            threshold->ThresholdByLower(thresholds[1]);
+        } else if(!std::isfinite(thresholds[1])) {
+            threshold->ThresholdByUpper(thresholds[0]);
+        } else {
+            threshold->ThresholdBetween(thresholds[0], thresholds[1]);
+        }
+    #endif
     threshold->Update();
     
     ///// Convert vtkPointSet into MATLAB struct /////


### PR DESCRIPTION
`vtkThreshold::ThresholdByLower`, `vtkThreshold::ThresholdByUpper`, `vtkThreshold::ThresholdBetween ` have been deprecated in VTK 9.1 and removed in VTK 9.3.

This PR propose to replace their usage if VTK_VERSION >= 9.1. 
